### PR TITLE
Major change for `ssb-custom-uri` compatibility.

### DIFF
--- a/lib/from-sigil-link.js
+++ b/lib/from-sigil-link.js
@@ -13,17 +13,18 @@ const sigils = {
 }
 
 const safe64 = (s) => {
-  return s.replace(/\+/g, '-').replace(/\//g, '_')
+  //return s.replace(/\+/g, '-').replace(/\//g, '_')
+  return encodeURIComponent(s)
 }
 
 var semantics = g.createSemantics().addOperation('toSsbUri', {
   sigilLink: function (sigil, base64, dot, commonAlgorithm) {
-    return [
-      'ssb',
+    let uri = [
       sigil.toSsbUri(),
       commonAlgorithm.toSsbUri(),
       base64.toSsbUri()
-    ].join(':')
+    ].join('/')
+    return `ssb:${uri}`
   },
   sigil: function (str) {
     return sigils[this.sourceString]
@@ -42,7 +43,7 @@ module.exports = (uri) => {
 }
 
 if (!module.parent) {
-  const uri = '%aUHk2iZgb7QPZVP5EWyJhW7EsZzgvlx3/VCrCOQYSZ0=.sha256'
+  const uri = '%EOgRe5ppgaugsqGyoWxJQ3QCFaGV7akjFUQ+9RR1jfk=.sha256'
 
   console.log(module.exports(uri))
 }

--- a/lib/grammar/ssb-uri.ohm
+++ b/lib/grammar/ssb-uri.ohm
@@ -1,7 +1,7 @@
 ssbURI {
 
 
-  uriCommon = scheme commonType commonAlgorithm integerBase64
+  uriCommon = scheme commonType commonAlgorithm encodedBase64
 
   queryPart = "?" uric*
 
@@ -14,7 +14,7 @@ ssbURI {
 
   escaped     = "%" hexDigit hexDigit
 
-  scheme = "ssb"
+  scheme = "ssb:"
 
   unreserved = alnum | mark
 
@@ -62,7 +62,7 @@ ssbURI {
 
   fragment = fragmentParts*
 
-  delimiter = ":"
+  delimiter = "/"
 
   segmentPart = (delimiter segmentNzNc)+
 
@@ -74,7 +74,7 @@ ssbURI {
     | "blob"
     | "channel"
 
-  commonType = delimiter commonTypePart
+  commonType = commonTypePart
 
   algorithm = delimiter unreserved*
 
@@ -95,6 +95,7 @@ ssbURI {
     | "-"
     | "_"
     | "="
+    | "%"
 
-  integerBase64 = delimiter base64Parts*
+  encodedBase64 = delimiter base64Parts*
 }

--- a/lib/to-sigil-link.js
+++ b/lib/to-sigil-link.js
@@ -13,19 +13,19 @@ const sigils = {
 }
 
 const unsafe64 = (s) => {
-  return s.replace('-', '+').replace('_', '/')
+  return decodeURIComponent(s)
 }
 
 var semantics = g.createSemantics().addOperation('toSigilLink', {
-  uriCommon: function (scheme, commonType, commonAlgorithm, integerBase64) {
+  uriCommon: function (scheme, commonType, commonAlgorithm, encodedBase64) {
     return [
       commonType.toSigilLink(),
-      integerBase64.toSigilLink(),
+      encodedBase64.toSigilLink(),
       '.',
       commonAlgorithm.toSigilLink()
     ].join('')
   },
-  commonType: function (delimiter, commonTypePart) {
+  commonType: function (commonTypePart) {
     return commonTypePart.toSigilLink()
   },
   commonTypePart: function (part) {
@@ -37,11 +37,11 @@ var semantics = g.createSemantics().addOperation('toSigilLink', {
   commonAlgorithmParts: function (part) {
     return this.sourceString
   },
-  integerBase64: function (delimiter, base64Parts) {
-    return base64Parts.toSigilLink().join('')
+  encodedBase64: function (delimiter, base64Parts) {
+    return unsafe64(base64Parts.toSigilLink().join(''))
   },
   base64Parts: function (part) {
-    return unsafe64(this.sourceString)
+    return this.sourceString
   }
 })
 
@@ -51,7 +51,7 @@ module.exports = (uri) => {
 }
 
 if (!module.parent) {
-  const uri = 'ssb:message:sha256:aUHk2iZgb7QPZVP5EWyJhW7EsZzgvlx3_VCrCOQYSZ0='
+  const uri = 'ssb:message/sha256/EOgRe5ppgaugsqGyoWxJQ3QCFaGV7akjFUQ%2B9RR1jfk%3D'
 
   console.log(module.exports(uri))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-uri",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-uri",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Uniform Resource Identifier (URI) utilities for Secure Scuttlebutt (SSB)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This changes grammars and associated routines to make it compatible with [`ssb-custom=uri`](https://git.sr.ht/~soapdog/ssb-custom-uri).

