### PR TITLE
remove `fs` dependency for easier browser usage

### DIFF
--- a/lib/from-sigil-link.js
+++ b/lib/from-sigil-link.js
@@ -1,9 +1,6 @@
-var fs = require('fs')
 var ohm = require('ohm-js')
-var path = require('path')
 
-const grammarPath = path.join(__dirname, './grammar/ssb-sigil-link.ohm')
-var g = ohm.grammar(fs.readFileSync(grammarPath))
+var g = ohm.grammar(require('./grammar/ssb-sigil-link.ohm'))
 
 const sigils = {
   '@': 'feed',

--- a/lib/grammar/ssb-sigil-link.ohm.js
+++ b/lib/grammar/ssb-sigil-link.ohm.js
@@ -1,3 +1,4 @@
+module.exports = `
 ssbSigilLink {
 
   sigilLink = sigil base64 "." commonAlgorithm
@@ -14,3 +15,4 @@ ssbSigilLink {
       | "="
     )*
 }
+`

--- a/lib/grammar/ssb-uri.ohm.js
+++ b/lib/grammar/ssb-uri.ohm.js
@@ -1,3 +1,4 @@
+module.exports = `
 ssbURI {
 
   uriCommon =
@@ -20,3 +21,4 @@ ssbURI {
   base64 = alnum | "-" | "_" | "="
 
 }
+`

--- a/lib/to-sigil-link.js
+++ b/lib/to-sigil-link.js
@@ -1,9 +1,6 @@
-var fs = require('fs')
-var path = require('path')
 var ohm = require('ohm-js')
 
-const grammarPath = path.join(__dirname, './grammar/ssb-uri.ohm')
-var g = ohm.grammar(fs.readFileSync(grammarPath))
+var g = ohm.grammar(require('./grammar/ssb-uri.ohm'))
 
 const sigils = {
   feed: '@',


### PR DESCRIPTION
Hi @christianbundy would you be open to a PR to remove the `fs` dependency from this module? The grammars have been converted to JS strings rather than files read in with `fs`. I was having some issues when using browserify and this is the solution I came up with, but maybe there is a better way.`